### PR TITLE
fix Lintian documentation/man issues

### DIFF
--- a/src/holders.hpp
+++ b/src/holders.hpp
@@ -174,7 +174,7 @@ void printStats(StatsHolder const & stats, LambdaOptions const & options)
                   << "\033[0m\n\n";
 
         if (rem != stats.hitsFinal)
-            std::cout << "WARNING: hits dont add up\n";
+            std::cout << "WARNING: hits don't add up\n";
     }
 
     if (options.verbosity >= 1)

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -587,14 +587,14 @@ parseCommandLine(LambdaOptions & options, int argc, char const ** argv)
 //         "STR"));
 //     setValidValues(parser, "query-alphabet", "dna5 aminoacid");
 //     setDefaultValue(parser, "query-alphabet", "dna5");
-// 
+//
 //     addOption(parser, ArgParseOption("da", "db-alphabet",
 //         "original alphabet of the subject sequences",
 //         ArgParseArgument::STRING,
 //         "STR"));
 //     setValidValues(parser, "db-alphabet", "dna5 aminoacid");
 //     setDefaultValue(parser, "db-alphabet", "aminoacid");
-// 
+//
 //     addOption(parser, ArgParseOption("sa", "seeding-alphabet",
 //         "alphabet to use during seeding (reduction possible)",
 //         ArgParseArgument::STRING,
@@ -710,7 +710,7 @@ parseCommandLine(LambdaOptions & options, int argc, char const ** argv)
     addSection(parser, "Scoring");
 
     addOption(parser, ArgParseOption("sc", "scoring-scheme",
-        "'45' for Blosum45; '62' for Blosum62 (default);  '80' for Blosum80; "
+        "use '45' for Blosum45; '62' for Blosum62 (default); '80' for Blosum80; "
         "[ignored for BlastN]",
         ArgParseArgument::INTEGER));
     setDefaultValue(parser, "scoring-scheme", "62");
@@ -1033,12 +1033,14 @@ parseCommandLine(LambdaIndexerOptions & options, int argc, char const ** argv)
     // Setup ArgumentParser.
     ArgumentParser parser("lambda_indexer");
 
+    setShortDescription(parser, "indexer for creating lambda-compatible databases");
+
     // Define usage line and long description.
     addUsageLine(parser, "[\\fIOPTIONS\\fP] \\-d DATABASE.fasta\\fP");
 
     sharedSetup(parser);
 
-    addDescription(parser, "This is the indexer_binary for creating a lambda-compatible databases.");
+    addDescription(parser, "This is the indexer_binary for creating lambda-compatible databases.");
 
     addSection(parser, "Input Options");
     addOption(parser, ArgParseOption("d", "database",


### PR DESCRIPTION
This PR addresses some issues I encountering while packaging:

 - spelling: "dont" -> "don't"
 - `lambda_indexer` didn't have a short description, leaving the corresponding field empty in the manpage (`--export-help man`)
 - I had to add an extra word in front of `'45'` as a singlequote at the beginning of a line apparently refers to a macro in the groff format, which leads to an error in the manpage (`--export-help man`)