### PR TITLE
[Fix] get correct ref names for sam/bam output

### DIFF
--- a/src/search_output.hpp
+++ b/src/search_output.hpp
@@ -363,8 +363,8 @@ myWriteHeader(TGH & globalHolder, TLambdaOptions const & options)
         for (unsigned i = 0; i < globalHolder.indexFile.ids.size(); ++i)
         {
             //TODO replace with assign algo
-            for (auto c : globalHolder.indexFile.ids[i] | seqan3::view::take_until(seqan3::is_space))
-                seqan::appendValue(subjIds, c);
+            subjIds[i] = globalHolder.indexFile.ids[i] | seqan3::view::take_until(seqan3::is_space)
+                                                       | std::ranges::to<std::string>;
         }
 
         typedef seqan::BamHeaderRecord::TTag   TTag;


### PR DESCRIPTION
Former version had some problems:
1) Resize followed by append results in empty reference names in sam output as first n names are empty strings 
2) Iterating through substring appends single characters to stringset