### PR TITLE
[FEATURE] re-activate bi-fm-index

### DIFF
--- a/src/mkindex.hpp
+++ b/src/mkindex.hpp
@@ -115,7 +115,7 @@ void argConv0(LambdaIndexerOptions & options)
     switch (options.indexFileOptions.indexType)
     {
         case DbIndexType::FM_INDEX:         return argConv1<DbIndexType::FM_INDEX>(options);
-        // case DbIndexType::BI_FM_INDEX:      return argConv1<DbIndexType::BI_FM_INDEX>(options);
+        case DbIndexType::BI_FM_INDEX:      return argConv1<DbIndexType::BI_FM_INDEX>(options);
         default:                            throw 42;
     }
 }

--- a/src/mkindex_algo.hpp
+++ b/src/mkindex_algo.hpp
@@ -706,7 +706,18 @@ auto generateIndex(TStringSet                       & seqs,
     myPrint(options, 1, "Generating Index...");
     double s = sysTime();
 
-    TIndex index = TIndex{seqs};
+    TIndex index;
+
+    if constexpr (is_bi)
+    {
+        // WORKAROUND https://github.com/seqan/seqan3/pull/1519
+        std::vector<std::vector<TRedAlph>> tmp = seqs | seqan3::views::to<std::vector<std::vector<TRedAlph>>>;
+        index = TIndex{tmp};
+    }
+    else
+    {
+        index = TIndex{seqs};
+    }
 
     double e = sysTime() - s;
     myPrint(options, 1, " done.\n");

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -219,7 +219,7 @@ argConv0(LambdaOptions & options)
     switch (options.indexFileOptions.indexType)
     {
         case DbIndexType::FM_INDEX:     return argConv1<DbIndexType::FM_INDEX>(options);
-        // case DbIndexType::BI_FM_INDEX:  return argConv1<DbIndexType::BI_FM_INDEX>(options);
+        case DbIndexType::BI_FM_INDEX:  return argConv1<DbIndexType::BI_FM_INDEX>(options);
         default: throw 52;
     }
 }

--- a/src/search_options.hpp
+++ b/src/search_options.hpp
@@ -293,7 +293,7 @@ void parseCommandLine(LambdaOptions & options, int argc, char const ** argv)
         seqan3::option_spec::DEFAULT, seqan3::arithmetic_range_validator{1, 50});
 
     parser.add_option(options.maxSeedDist, '\0', "seed-delta",
-        "Maximum seed distance.", seqan3::option_spec::ADVANCED, seqan3::arithmetic_range_validator{0, 1});
+        "Maximum seed distance.", seqan3::option_spec::ADVANCED, seqan3::arithmetic_range_validator{0, 5});
 
     parser.add_option(options.seedDeltaIncreasesLength, '\0', "seed-delta-increases-length",
         "Seed delta increases the min. seed length (for affected seeds).", seqan3::option_spec::ADVANCED);


### PR DESCRIPTION
This PR re-activates the BI-FM-Index. It contains a workaround for a build-failure in GCC7 (https://github.com/seqan/seqan3/pull/1519).

But at least on my systems, this still ICEs on GCC8 and GCC9. Can you verify this, @sarahet ?

I have reported this here: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92778

Some preliminary tests with bifm (using wavelet trees) are promising (20% raw speed-up, possibly more with different strategies).