### PR TITLE
[FEATURE] make adaptive seeding available again

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -191,22 +191,7 @@ set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SEQAN_CXX_FLAGS} -Wall -pedantic")
 
 # Update the list of file names below if you add source files to your application.
-set (LAMBDA_SOURCE_FILES
-                lambda.cpp
-                    shared_definitions.hpp
-                    shared_misc.hpp
-                    shared_options.hpp
-                search.hpp
-                    search_algo.hpp
-                    search_datastructures.hpp
-                    search_misc.hpp
-                    search_output.hpp
-                    search_options.hpp
-                mkindex.hpp
-                    mkindex_algo.hpp
-                    mkindex_misc.hpp
-                    mkindex_options.hpp
-                    mkindex_saca.hpp)
+set (LAMBDA_SOURCE_FILES lambda.cpp  search.cpp mkindex.cpp)
 
 add_executable (lambda3 ${LAMBDA_SOURCE_FILES})
 target_link_libraries (lambda3 ${SEQAN_LIBRARIES} seqan3::seqan3)

--- a/src/lambda.cpp
+++ b/src/lambda.cpp
@@ -25,7 +25,7 @@
 
 #include "search.hpp"
 #include "mkindex.hpp"
-// using namespace seqan;
+#include "shared_options.hpp"
 
 void parseCommandLineMain(int argc, char const ** argv);
 

--- a/src/mkindex.cpp
+++ b/src/mkindex.cpp
@@ -19,6 +19,8 @@
 // lambda.cpp: Main File for the main application
 // ==========================================================================
 
+#include "seqan2seqan3.hpp" // must come first
+
 #include <initializer_list>
 #include <iostream>
 
@@ -36,8 +38,6 @@
 #include "mkindex_options.hpp"
 // #include "mkindex_saca.hpp"
 #include "mkindex_algo.hpp"
-
-// using namespace seqan;
 
 // ==========================================================================
 // Forwards

--- a/src/mkindex.hpp
+++ b/src/mkindex.hpp
@@ -1,0 +1,24 @@
+// ==========================================================================
+//                                  lambda
+// ==========================================================================
+// Copyright (c) 2013-2019, Hannes Hauswedell <h2 @ fsfe.org>
+// Copyright (c) 2016-2019, Knut Reinert and Freie Universität Berlin
+// All rights reserved.
+//
+// This file is part of Lambda.
+//
+// Lambda is Free Software: you can redistribute it and/or modify it
+// under the terms found in the LICENSE[.md|.rst] file distributed
+// together with this file.
+//
+// Lambda is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+// ==========================================================================
+// lambda.hpp: Main File for the main application
+// ==========================================================================
+
+#pragma once
+
+int mkindexMain(int const argc, char const ** argv);

--- a/src/mkindex_options.hpp
+++ b/src/mkindex_options.hpp
@@ -25,6 +25,8 @@
 #include <unistd.h>
 #include <bitset>
 
+#include <seqan3/argument_parser/all.hpp>
+
 // --------------------------------------------------------------------------
 // Class LambdaIndexerOptions
 // --------------------------------------------------------------------------

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -19,7 +19,7 @@
 // lambda.cpp: Main File for Lambda
 // ==========================================================================
 
-#pragma once
+#include "seqan2seqan3.hpp" // must come first
 
 #include <iostream>
 

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -1,0 +1,24 @@
+// ==========================================================================
+//                                  lambda
+// ==========================================================================
+// Copyright (c) 2013-2019, Hannes Hauswedell <h2 @ fsfe.org>
+// Copyright (c) 2016-2019, Knut Reinert and Freie Universität Berlin
+// All rights reserved.
+//
+// This file is part of Lambda.
+//
+// Lambda is Free Software: you can redistribute it and/or modify it
+// under the terms found in the LICENSE[.md|.rst] file distributed
+// together with this file.
+//
+// Lambda is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+// ==========================================================================
+// lambda.cpp: Main File for Lambda
+// ==========================================================================
+
+#pragma once
+
+int searchMain(int const argc, char const ** argv);

--- a/src/search_datastructures.hpp
+++ b/src/search_datastructures.hpp
@@ -408,6 +408,11 @@ public:
     using TQryIds       = TIds;
     using TSubjIds      = TIds;
 
+    /* index */
+    using TIndexFile    = index_file<c_dbIndexType, c_origSbjAlph, c_redAlph>;
+    using TIndex        = typename TIndexFile::TIndex;
+    using TIndexCursor  = typename TIndex::cursor_type;
+
     /* output file */
     using TScoreScheme3  = std::conditional_t<seqan3::nucleotide_alphabet<TRedAlph>,
                                               seqan3::nucleotide_scoring_scheme<>,
@@ -426,7 +431,7 @@ public:
     using TPositions    = std::vector<size_t>;
 
     /* the actual members */
-    index_file<c_dbIndexType, c_origSbjAlph, c_redAlph> indexFile;
+    TIndexFile          indexFile;
 
     TTransSbjSeqs       transSbjSeqs =
         initHelper<TTransAlph>(indexFile.seqs, seqan3::views::translate_join, seqan3::views::translate_join);
@@ -512,10 +517,12 @@ public:
     uint64_t            indexBeginQry;
     uint64_t            indexEndQry;
 
-    // regarding seedingp
-    std::vector<TMatch>   matches;
-    std::vector<typename TMatch::TQId> seedRefs;  // mapping seed -> query
-    std::vector<typename TMatch::TPos> seedRanks; // mapping seed -> relative rank
+    // regarding seeding
+    std::vector<typename TGlobalHolder::TIndexCursor>   cursor_buffer;
+    std::vector<std::pair<size_t, size_t>>              matches_buffer;
+    std::vector<TMatch>                                 matches;
+    std::vector<typename TMatch::TQId>                  seedRefs;  // mapping seed -> query
+    std::vector<typename TMatch::TPos>                  seedRanks; // mapping seed -> relative rank
 
     // regarding extension
 //     using TAlignRow = seqan::Gaps<seqan::Infix<typename TGlobalHolder::TSeqAn2TransSeq>,

--- a/src/search_options.hpp
+++ b/src/search_options.hpp
@@ -616,11 +616,12 @@ printOptions(LambdaOptions const & options)
               << "  seed length:              " << uint(options.seedLength) << "\n"
               << "  seed offset:              " << uint(options.seedOffset) << "\n"
               << "  seed delta:               " << uint(options.maxSeedDist) << "\n"
-              << "  seeds ungapped:           " << uint(options.hammingOnly) << "\n"
-              << "  seed gravity:             " << uint(options.seedGravity) << "\n"
-              << "  seed delta length inc.:   " << (options.seedDeltaIncreasesLength
-                                                    ? std::string("on")
-                                                    : std::string("off")) << "\n"
+              << "  adaptive seeding:         " << uint(options.adaptiveSeeding) << "\n"
+//               << "  seeds ungapped:           " << uint(options.hammingOnly) << "\n"
+//               << "  seed gravity:             " << uint(options.seedGravity) << "\n"
+//               << "  seed delta length inc.:   " << (options.seedDeltaIncreasesLength
+//                                                     ? std::string("on")
+//                                                     : std::string("off")) << "\n"
               << " MISCELLANEOUS HEURISTICS\n"
               << "  pre-scoring:              " << (options.preScoring
                                                     ? std::string("on")

--- a/src/search_options.hpp
+++ b/src/search_options.hpp
@@ -31,8 +31,8 @@
 #include <seqan/index.h>
 #include <seqan/blast.h>
 
+#include <seqan3/argument_parser/all.hpp>
 #include <seqan3/std/filesystem>
-
 
 // ==========================================================================
 // Forwards

--- a/src/shared_misc.hpp
+++ b/src/shared_misc.hpp
@@ -121,7 +121,7 @@ constexpr bool all_valid(TRange && r)
     return true;
 }
 
-AlphabetEnum detectSeqFileAlphabet(std::string const & path)
+inline AlphabetEnum detectSeqFileAlphabet(std::string const & path)
 {
     seqan3::sequence_file_input<alphabet_detection_traits, seqan3::fields<seqan3::field::seq>> f{path};
 
@@ -387,7 +387,7 @@ inline double sysTime()
 // Function fileSize()
 // ----------------------------------------------------------------------------
 
-uint64_t fileSize(char const * fileName)
+inline uint64_t fileSize(char const * fileName)
 {
     struct stat st;
     if (stat(fileName, &st) != 0)
@@ -399,7 +399,7 @@ uint64_t fileSize(char const * fileName)
 // Function dirSize()
 // ----------------------------------------------------------------------------
 
-uint64_t dirSize(char const * dirName)
+inline uint64_t dirSize(char const * dirName)
 {
     DIR *d;
     struct dirent *de;
@@ -434,7 +434,7 @@ uint64_t dirSize(char const * dirName)
 // Function fileSize()
 // ----------------------------------------------------------------------------
 
-uint64_t getTotalSystemMemory()
+inline uint64_t getTotalSystemMemory()
 {
 #if defined(__APPLE__)
     uint64_t mem;

--- a/src/shared_options.hpp
+++ b/src/shared_options.hpp
@@ -32,6 +32,7 @@
 #include <seqan3/alphabet/aminoacid/aa10murphy.hpp>
 #include <seqan3/alphabet/aminoacid/aa10li.hpp>
 #include <seqan3/alphabet/aminoacid/translation_genetic_code.hpp>
+#include <seqan3/argument_parser/all.hpp>
 #include <seqan3/std/filesystem>
 
 // #include <seqan/basic.h>
@@ -291,7 +292,7 @@ struct SharedOptions
 // Function sharedSetup()
 // --------------------------------------------------------------------------
 
-void sharedSetup(seqan3::argument_parser & parser)
+inline void sharedSetup(seqan3::argument_parser & parser)
 {
     // Set short description, version, and date
     parser.info.version = SEQAN_APP_VERSION;


### PR DESCRIPTION
Making the internal search ourselves has quite positive effect on performance. 

Current version of adaptive seeding is very conservative and only brings 0-10% speed improvement (but it also doesn't make anything worse).

Splitting the translation units reduces compile time drastically again. Attention: if review the commits individually the diff is correct and shows files being renamed, but if you look at the total diff, it looks like huge copy'n'paste.