### PR TITLE
[Fix] Get correct number of header entries for subject sequences

### DIFF
--- a/src/search_output.hpp
+++ b/src/search_output.hpp
@@ -330,7 +330,7 @@ myWriteHeader(TGH & globalHolder, TLambdaOptions const & options)
         if (sIsTranslated(TGH::blastProgram))
         {
             //TODO can we get around a copy?
-            subjSeqLengths = globalHolder.untransSubjSeqLengths;
+            subjSeqLengths = prefix(globalHolder.untransSubjSeqLengths, length(globalHolder.untransSubjSeqLengths) - 1);
         } else
         {
             // compute lengths ultra-fast


### PR DESCRIPTION
For translated databases, the number of original sequence lengths was used to determine the header entries. The last entry of the original sequence lengths is however the sum, so one empty header line was accidentally created in this case.