### PR TITLE
[Fix] correct CIGAR string in SAM format as well as correct header in…

### DIFF
--- a/src/mkindex_options.hpp
+++ b/src/mkindex_options.hpp
@@ -116,7 +116,7 @@ void parseCommandLine(LambdaIndexerOptions & options, int argc, char const ** ar
 
     std::string dbIndexTypeTmp = "fm";
     parser.add_option(dbIndexTypeTmp, '\0', "db-index-type", "FM-Index oder bidirectional FM-Index.",
-        seqan3::option_spec::ADVANCED);
+        seqan3::option_spec::ADVANCED, seqan3::value_list_validator{"fm", "bifm"});
 
     parser.add_option(options.truncateIDs, '\0', "truncate-ids",
         "Truncate IDs at first whitespace. This saves a lot of space and is irrelevant for all LAMBDA output formats "

--- a/src/search_algo.hpp
+++ b/src/search_algo.hpp
@@ -1216,6 +1216,7 @@ iterateMatchesFullSerial(TLocalHolder & lH)
     auto const trueQryId = lH.matches[0].qryId / qNumFrames(TGlobalHolder::blastProgram);
 
     TBlastRecord record(lH.gH.qryIds[trueQryId]);
+    record.qLength = seqan::length(lH.gH.qrySeqs[trueQryId]);
 
     size_t band = _bandSize(seqan::length(lH.gH.transQrySeqs[lH.matches[0].qryId]), lH);
 

--- a/src/search_output.hpp
+++ b/src/search_output.hpp
@@ -128,6 +128,7 @@ blastMatchOneCigar(TCigar & cigar,
     // clips resulting from translation / frameshift are always hard clips
     unsigned const leftFrameClip  = std::abs(m.qFrameShift) - 1;
     unsigned const rightFrameClip = qIsTranslated(TGlobalHolder::blastProgram) ? (r.qLength - leftFrameClip) % 3 : 0;
+
     // regular clipping from local alignment (regions outside match) can be hard or soft
     unsigned const leftClip       = m.qStart * transFac;
     unsigned const rightClip      = (seqan::length(seqan::source(m.alignRow0)) - m.qEnd) * transFac;
@@ -353,9 +354,9 @@ myWriteHeader(TGH & globalHolder, TLambdaOptions const & options)
         auto & subjIds          = seqan::contigNames(context);
 
         // compute seqan::lengths ultra-fast
-        seqan::resize(subjSeqLengths, globalHolder.redSbjSeqs.size());
+        seqan::resize(subjSeqLengths, globalHolder.indexFile.seqs.size());
         SEQAN_OMP_PRAGMA(parallel for simd)
-        for (size_t i = 0; i < globalHolder.redSbjSeqs.size(); ++i)
+        for (size_t i = 0; i < globalHolder.indexFile.seqs.size(); ++i)
             subjSeqLengths[i] = globalHolder.indexFile.seqs[i].size();
 
         // set namestore
@@ -467,7 +468,6 @@ myWriteRecord(TLH & lH, TRecord const & record)
     } else // SAM or BAM
     {
         // convert multi-match blast-record to multiple SAM/BAM-Records
-
         std::vector<seqan::BamAlignmentRecord> bamRecords;
         bamRecords.resize(record.matches.size());
 


### PR DESCRIPTION
… bam format

Already known problem with macth/record qLength entries.
Wrong number of sequences used for the BAM header