### PR TITLE
Feat/heapless halfexact backtracking

### DIFF
--- a/src/search_datastructures.hpp
+++ b/src/search_datastructures.hpp
@@ -478,8 +478,6 @@ public:
 
     // regarding seeding
     std::vector<typename TGlobalHolder::TIndexCursor>                    cursor_buffer;
-    std::vector<std::pair<typename TGlobalHolder::TIndexCursor, size_t>> cursor_tmp_buffer;
-    std::vector<std::pair<typename TGlobalHolder::TIndexCursor, size_t>> cursor_tmp_buffer2;
     std::vector<size_t>                                                  offset_modifier_buffer;
     std::vector<std::pair<size_t, size_t>>                               matches_buffer;
     std::vector<TMatch>                                                  matches;


### PR DESCRIPTION
This is based on (and blocked by) #176 

It changes the halfExact search by removing the heap structures and replacing it with recursive function calls.

This still needs performance evaluation, to make sure it is not slower than before.