### PR TITLE
update to current SeqAn3 master and add compiler workarounds

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 120
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - name: "gcc11"

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: macos-10.15
     timeout-minutes: 120
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - name: "gcc11"

--- a/src/bisulfite_scoring.hpp
+++ b/src/bisulfite_scoring.hpp
@@ -24,8 +24,6 @@
 #include <seqan/score.h>
 #include <seqan/sequence.h>
 
-#include <range/v3/algorithm/copy.hpp>
-
 #include <seqan3/alignment/scoring/scoring_scheme_base.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <algorithm>

--- a/src/mkindex_algo.hpp
+++ b/src/mkindex_algo.hpp
@@ -119,7 +119,7 @@ auto loadSubjSeqsAndIds(LambdaIndexerOptions const & options)
             extractAccIds(id, count);
 
         if (options.truncateIDs)
-            ids.push_back(id | seqan3::detail::take_until(seqan3::is_space) | seqan3::views::to<std::string>);
+            ids.push_back(id | seqan3::detail::take_until(seqan3::is_space) | seqan3::ranges::to<std::string>());
         else
             ids.push_back(std::move(id));
 
@@ -375,7 +375,7 @@ auto parseAndStoreTaxTree(std::vector<bool>          & taxIdIsPresent,
     while (std::ranges::begin(file_view) != std::ranges::end(file_view))
     {
         // read line
-        buf = file_view | std::views::take_while(not_eol) | seqan3::views::to<std::string>;
+        buf = file_view | std::views::take_while(not_eol) | seqan3::ranges::to<std::string>();
 
         uint32_t n = 0;
         uint32_t parent = 0;
@@ -568,7 +568,7 @@ auto parseAndStoreTaxTree(std::vector<bool>          & taxIdIsPresent,
     while (std::ranges::begin(file_view2) != std::ranges::end(file_view2))
     {
         // read line
-        buf = file_view2 | std::views::take_while(not_eol) | seqan3::views::to<std::string>;
+        buf = file_view2 | std::views::take_while(not_eol) | seqan3::ranges::to<std::string>();
 
         uint32_t taxId = 0;
 
@@ -651,7 +651,7 @@ auto generateIndex(TStringSet                       & seqs,
     if constexpr (is_bi)
     {
         // WORKAROUND https://github.com/seqan/seqan3/pull/1519
-        std::vector<std::vector<TRedAlph>> tmp = seqs | seqan3::views::to<std::vector<std::vector<TRedAlph>>>;
+        std::vector<std::vector<TRedAlph>> tmp = seqs | seqan3::ranges::to<std::vector<std::vector<TRedAlph>>>();
         index = TIndex{tmp};
     }
     else

--- a/src/mkindex_misc.hpp
+++ b/src/mkindex_misc.hpp
@@ -57,11 +57,11 @@ _readMappingFileUniProt(TInputView                                            & 
     while (std::ranges::begin(fiv) != std::ranges::end(fiv))
     {
         // read accession number
-        acc = fiv | std::views::take_while(!seqan3::is_blank) | seqan3::views::to<std::string>; //TODO and_consume
+        acc = fiv | std::views::take_while(!seqan3::is_blank) | seqan3::ranges::to<std::string>(); //TODO and_consume
         // skip whitespace
         seqan3::detail::consume(fiv | std::views::take_while(!seqan3::is_alnum));
         // read accession number
-        nextColumn = fiv | std::views::take_while(!seqan3::is_blank) | seqan3::views::to<std::string>; //TODO and_consume
+        nextColumn = fiv | std::views::take_while(!seqan3::is_blank) | seqan3::ranges::to<std::string>(); //TODO and_consume
 
         if ((nextColumn == "NCBI_TaxID") && (accToIdRank.count(acc) == 1))
         {
@@ -69,7 +69,7 @@ _readMappingFileUniProt(TInputView                                            & 
             // skip whitespace
             seqan3::detail::consume(fiv | std::views::take_while(!seqan3::is_alnum));
             // read tax id
-            nextColumn = fiv | std::views::take_while(!seqan3::is_space) | seqan3::views::to<std::string>; //TODO and_consume
+            nextColumn = fiv | std::views::take_while(!seqan3::is_space) | seqan3::ranges::to<std::string>(); //TODO and_consume
 
             uint32_t idNum = 0;
             auto [p, ec] = std::from_chars(nextColumn.data(), nextColumn.data() + nextColumn.size(), idNum);
@@ -107,7 +107,7 @@ _readMappingFileNCBI(TInputView                                            & fiv
     while (std::ranges::begin(fiv) != std::ranges::end(fiv))
     {
         // read accession number
-        buf = fiv | std::views::take_while(!seqan3::is_blank) | seqan3::views::to<std::string>; //TODO and_consume
+        buf = fiv | std::views::take_while(!seqan3::is_blank) | seqan3::ranges::to<std::string>(); //TODO and_consume
         // we have a sequence with this ID in our database
         if (accToIdRank.count(buf) == 1)
         {
@@ -119,7 +119,7 @@ _readMappingFileNCBI(TInputView                                            & fiv
             // skip whitespace
             seqan3::detail::consume(fiv | std::views::take_while(!seqan3::is_alnum));
             // read tax id
-            buf = fiv | std::views::take_while(!seqan3::is_blank) | seqan3::views::to<std::string>; //TODO and_consume
+            buf = fiv | std::views::take_while(!seqan3::is_blank) | seqan3::ranges::to<std::string>(); //TODO and_consume
 
             uint32_t idNum = 0;
             auto [p, ec] = std::from_chars(buf.data(), buf.data() + buf.size(), idNum);

--- a/src/search_output.hpp
+++ b/src/search_output.hpp
@@ -366,7 +366,7 @@ myWriteHeader(TGH & globalHolder, TLambdaOptions const & options)
         {
             //TODO replace with assign algo
             subjIds[i] = globalHolder.indexFile.ids[i] | seqan3::detail::take_until(seqan3::is_space)
-                                                       | seqan3::views::to<std::string>;
+                                                       | seqan3::ranges::to<std::string>();
         }
 
         typedef seqan::BamHeaderRecord::TTag   TTag;

--- a/src/view_pos_transform.hpp
+++ b/src/view_pos_transform.hpp
@@ -35,13 +35,13 @@ class view_pos_transform : public std::ranges::view_base
 
 private:
     // The data members of view_pos_transform.
-    urng_t                                        urange;
-    ::ranges::semiregular_box_t<pos_transform_t>  pos_transform;
-    ::ranges::semiregular_box_t<size_transform_t> size_transform;
+    std::optional<urng_t>           urange;
+    std::optional<pos_transform_t>  pos_transform;
+    std::optional<size_transform_t> size_transform;
 
     // Associated types iterator.
-    using reference         = decltype(pos_transform(urange, 0));
-    using const_reference   = decltype(pos_transform(std::as_const(urange), 0));
+    using reference         = decltype((*pos_transform)(*urange, 0));
+    using const_reference   = decltype((*pos_transform)(std::as_const(*urange), 0));
     using value_type        = std::remove_cvref_t<reference>;
     using size_type         = std::ranges::range_size_t<urng_t>;
     using difference_type   = std::ranges::range_difference_t<urng_t>;
@@ -62,7 +62,7 @@ public:
                   "The range parameter to views::pos_transform must model std::ranges::sized_range.");
 
     // Constructors, destructor and assignment
-    view_pos_transform()                                                     noexcept = default; //!< Defaulted.
+    view_pos_transform() noexcept                                                     = default; //!< Defaulted.
     constexpr view_pos_transform(view_pos_transform const & rhs)             noexcept = default; //!< Defaulted.
     constexpr view_pos_transform(view_pos_transform && rhs)                  noexcept = default; //!< Defaulted.
     constexpr view_pos_transform & operator=(view_pos_transform const & rhs) noexcept = default; //!< Defaulted.
@@ -80,7 +80,7 @@ public:
     template <typename rng_t>
         requires (!std::same_as<std::remove_cvref_t<rng_t>, view_pos_transform> &&
                   (std::ranges::viewable_range<rng_t> &&
-                  std::constructible_from<urng_t, ranges::ref_view<std::remove_reference_t<rng_t>>>))
+                  std::constructible_from<urng_t, std::ranges::ref_view<std::remove_reference_t<rng_t>>>))
     view_pos_transform(rng_t && _urange, pos_transform_t _pos_transform, size_transform_t _size_transform)
      : view_pos_transform{std::views::all(std::forward<rng_t>(_urange)),
                           std::move(_pos_transform),
@@ -113,27 +113,27 @@ public:
     // Returns the number of elements in the view.
     size_type size() noexcept
     {
-        return size_transform(urange);
+        return (*size_transform)(*urange);
     }
 
     size_type size() const noexcept
         requires seqan3::const_iterable_range<urng_t>
     {
-        return size_transform(urange);
+        return (*size_transform)(*urange);
     }
 
     // Element access
     reference operator[](size_type const n)
     {
         assert(n < size());
-        return pos_transform(urange, n);
+        return (*pos_transform)(*urange, n);
     }
 
     const_reference operator[](size_type const n) const
         requires seqan3::const_iterable_range<urng_t>
     {
         assert(n < size());
-        return pos_transform(urange, n);
+        return (*pos_transform)(*urange, n);
     }
 };
 


### PR DESCRIPTION
This fixes problems with newer versions of GCC11 and fixes *some* of the problems with GCC10.4, but that last remaining problem I have been unable to fix in the last couple of hours. We will see this on Linux as well as soon as that gets GCC10.4 :|

@SGSSGene do you like weird compiler problems and want to give it a try? 😉 

In any case, I think we can merge these changes (although they are also workarounds at best).