### PR TITLE
patch: explicit paths for 0 and 1 error searches in bifmindex

### DIFF
--- a/src/search_algo.hpp
+++ b/src/search_algo.hpp
@@ -422,7 +422,7 @@ search_impl(LocalDataHolder<TGlobalHolder> & lH, TSeed && seed)
     }
     else if constexpr (TGlobalHolder::c_dbIndexType == DbIndexType::BI_FM_INDEX)
     {
-        if (lH.options.maxSeedDist == 0)
+        if (lH.searchOpts.maxSeedDist == 0)
         {
             [&]()
             {
@@ -443,7 +443,7 @@ search_impl(LocalDataHolder<TGlobalHolder> & lH, TSeed && seed)
                 lH.cursor_buffer.push_back(cur);
             }();
         }
-        else if (lH.options.maxSeedDist == 1)
+        else if (lH.searchOpts.maxSeedDist == 1)
         {
             fmindex_collection::search_one_error::search(
                 lH.gH.indexFile.index,

--- a/src/search_algo.hpp
+++ b/src/search_algo.hpp
@@ -422,8 +422,10 @@ search_impl(LocalDataHolder<TGlobalHolder> & lH, TSeed && seed)
     }
     else if constexpr (TGlobalHolder::c_dbIndexType == DbIndexType::BI_FM_INDEX)
     {
-        if (lH.options.maxSeedDist == 0) {
-            [&]() {
+        if (lH.options.maxSeedDist == 0)
+        {
+            [&]()
+            {
                 using cursor_t = TGlobalHolder::TIndexCursor;
 
                 auto query = seed | seqan3::views::to_rank | fmindex_collection::add_sentinel;
@@ -440,7 +442,9 @@ search_impl(LocalDataHolder<TGlobalHolder> & lH, TSeed && seed)
                 }
                 lH.cursor_buffer.push_back(cur);
             }();
-        } else if (lH.options.maxSeedDist == 1) {
+        }
+        else if (lH.options.maxSeedDist == 1)
+        {
             fmindex_collection::search_one_error::search(
                 lH.gH.indexFile.index,
                 seed | seqan3::views::to_rank | fmindex_collection::add_sentinel,
@@ -449,7 +453,9 @@ search_impl(LocalDataHolder<TGlobalHolder> & lH, TSeed && seed)
                     lH.cursor_buffer.push_back(cursor);
                 }
             );
-        } else {
+        }
+        else
+        {
             fmindex_collection::search_pseudo::search</*editdistance=*/false>(
                 lH.gH.indexFile.index,
                 seed | seqan3::views::to_rank | fmindex_collection::add_sentinel,


### PR DESCRIPTION
This adds explicit paths for searches with up to 0 and 1 error using the bifmindex.
Improvements of the runtimes are not impressive. My test show following:

Searches using `--seed-delta 0` running the program 5 times:
```
lambda3: 1.53 1.55 1.53 1.52 1.55
this PR: 1.45 1.49 1.43 1.43 1.45
```

Searches using `--seed-delta 1` running the program 5 times:
```
lambda3: 2.53 2.58 2.62 2.58 2.53
this PR: 2.42 2.40 2.38 2.38 2.36
```
