### PR TITLE
[fix] view madness in seqan2

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake ../lambda -DLAMBDA_COMPILE_THREADS=2 -DLAMBDA_NATIVE_BUILD=ON -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
+          cmake ../lambda -DLAMBDA_COMPILE_THREADS=2 -DLAMBDA_NATIVE_BUILD=OFF -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
 
       - name: Build tests
         if: matrix.name != 'clang_format'

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -21,6 +21,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - name: "gcc12"
+            install: "g++-12"
+            cxx: "g++-12"
+            cc: "gcc-12"
+            build_type: Release
+
           - name: "gcc11"
             install: "g++-11"
             cxx: "g++-11"

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -22,9 +22,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "gcc11"
-            cxx: "g++-11"
-            cc: "gcc-11"
+          - name: "gcc12"
+            cxx: "g++-12"
+            cc: "gcc-12"
             build_type: Release
 
           - name: "gcc10"

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake ../lambda -DLAMBDA_COMPILE_THREADS=3 -DLAMBDA_NATIVE_BUILD=ON -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
+          cmake ../lambda -DLAMBDA_COMPILE_THREADS=3 -DLAMBDA_NATIVE_BUILD=OFF -DCMAKE_CXX_FLAGS="${{ matrix.cxx_flags }}" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
 
       - name: Build tests
         env:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,8 @@ if (LAMBDA_NATIVE_BUILD)
     if (CMAKE_CXX_COMPILER_ID MATCHES "Intel")
         set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -xHOST -ipo -no-prec-div -fp-model fast=2")
     endif (CMAKE_CXX_COMPILER_ID MATCHES "Intel")
+else (LAMBDA_NATIVE_BUILD)
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mmmx -msse -msse2 -msse3 -mssse3 -msse4 -mpopcnt")
 endif (LAMBDA_NATIVE_BUILD)
 
 if (LAMBDA_STATIC_BUILD)

--- a/src/holder_tristate_overload.h
+++ b/src/holder_tristate_overload.h
@@ -1,0 +1,224 @@
+// ==========================================================================
+//                 SeqAn - The Library for Sequence Analysis
+// ==========================================================================
+// Copyright (c) 2006-2018, Knut Reinert, FU Berlin
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Knut Reinert or the FU Berlin nor the names of
+//       its contributors may be used to endorse or promote products derived
+//       from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL KNUT REINERT OR THE FU BERLIN BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+// DAMAGE.
+//
+// ==========================================================================
+// Author: Andreas Gogol-Döring <andreas.doering@mdc-berlin.de>
+// ==========================================================================
+// Tristate Holder Implementation.
+// ==========================================================================
+
+#pragma once
+
+#include <seqan/basic.h>
+
+using overload_t = std::ranges::take_view<std::ranges::drop_view<seqan3::detail::view_translate_single<std::ranges::ref_view<std::vector<seqan3::dna5>>>>>;
+
+template <typename t>
+concept overload_c = std::same_as<std::remove_cvref_t<t>, overload_t>;
+
+namespace seqan
+{
+
+// ============================================================================
+// Tags, Classes, Enums
+// ============================================================================
+template <overload_c TValue>
+struct Holder<TValue, Tristate>
+{
+    enum EHolderState
+    {
+        EMPTY = 0,
+        OWNER = 1,
+        DEPENDENT = 2
+    };
+
+    typedef std::optional<TValue> THostValue;
+
+    // ------------------------------------------------------------------------
+    // Members
+    // ------------------------------------------------------------------------
+
+    THostValue data_value;
+    EHolderState data_state;
+
+    // ------------------------------------------------------------------------
+    // Constructors; Destructor
+    // ------------------------------------------------------------------------
+
+    Holder() : data_value{}, data_state(EMPTY)
+    {
+    }
+
+    Holder(Holder const & source_) : data_value{}, data_state(EMPTY)
+    {
+        data_value = source_;
+    }
+
+    explicit
+    Holder(THostValue & value_) : data_value{}, data_state(EMPTY)
+    {
+        data_value = value_;
+    }
+
+    explicit
+    Holder(THostValue const & value_) : data_value{}, data_state(EMPTY)
+    {
+        data_value = value_;
+    }
+
+    ~Holder()
+    {
+        clear(*this);
+    }
+
+    // ------------------------------------------------------------------------
+    // Assignment Operators;  Must be defined in class.
+    // ------------------------------------------------------------------------
+
+    Holder & operator=(Holder const &) = default;
+
+    Holder & operator=(THostValue const & value_)
+    {
+        data_value = value_;
+        return *this;
+    }
+
+    // ------------------------------------------------------------------------
+    // Conversion Operators;  Must be defined in class.
+    // ------------------------------------------------------------------------
+
+    inline operator THostValue()
+    {
+        return data_value;
+    }
+};
+
+// ============================================================================
+// Functions
+// ============================================================================
+
+/// ----------------------------------------------------------------------------
+// Function clear()
+// ----------------------------------------------------------------------------
+
+template <overload_c TValue>
+inline void
+clear(Holder<TValue, Tristate> & me)
+{
+    me.data_value.reset();
+    me.data_state = Holder<TValue, Tristate>::EMPTY;
+}
+
+// ----------------------------------------------------------------------------
+// Function setValue()
+// ----------------------------------------------------------------------------
+
+template <overload_c TValue>
+inline void
+setValue(Holder<TValue, Tristate> & me,
+         TValue const & value_)
+{
+    me.data_value = value_;
+    me.data_state = Holder<TValue, Tristate>::OWNER;
+}
+
+template <overload_c TValue>
+inline void
+setValue(Holder<TValue const, Tristate> & me,
+         TValue const & value_)
+{
+    me.data_value = value_;
+    me.data_state = Holder<TValue const, Tristate>::OWNER;
+}
+
+// ----------------------------------------------------------------------------
+// Function value()
+// ----------------------------------------------------------------------------
+
+template <overload_c TValue>
+auto & value(Holder<TValue, Tristate> & me)
+{
+    SEQAN_ASSERT_NOT(empty(me)); // HERE BE DRAGONS!!!
+    return * me.data_value;
+}
+
+template <overload_c TValue>
+auto & value(Holder<TValue, Tristate> const & me)
+{
+    SEQAN_ASSERT_NOT(empty(me));
+
+    return * me.data_value;
+}
+
+// ----------------------------------------------------------------------------
+// Function assignValue()
+// ----------------------------------------------------------------------------
+
+template <overload_c TValue, typename TSource>
+inline void
+assignValue(Holder<TValue, Tristate> & me,
+            TSource const & value_)
+{
+    setValue(me, value_);
+}
+
+// ----------------------------------------------------------------------------
+// Function moveValue()
+// ----------------------------------------------------------------------------
+
+template <overload_c TValue, typename TSource>
+inline void
+moveValue(Holder<TValue, Tristate> & me,
+          TSource const & value_)
+{
+    setValue(me, value_);
+}
+
+// ----------------------------------------------------------------------------
+// Function assign()
+// ----------------------------------------------------------------------------
+
+template <overload_c TValue>
+inline void
+assign(Holder<TValue, Tristate> & target_,
+       Holder<TValue, Tristate> const & source_)
+{
+    target_ = source_;
+}
+
+template <overload_c TValue>
+inline void
+assign(Holder<TValue const, Tristate> & target_,
+       Holder<TValue const, Tristate> const & source_)
+{
+    target_ = source_;
+}
+
+}  // namespace seqan

--- a/src/seqan2seqan3.hpp
+++ b/src/seqan2seqan3.hpp
@@ -57,6 +57,7 @@ inline seqan3::gapped<alph_t> gapValueImpl(seqan3::gapped<alph_t> const *)
 #include <seqan/score.h>
 #include <seqan/sequence.h>
 
+#include "holder_tristate_overload.h"
 #include "bisulfite_scoring.hpp"
 
 namespace seqan
@@ -213,6 +214,25 @@ struct GetValue<Iter<TContainer const, StdIteratorAdaptor>>
 {
     using Type = std::ranges::range_reference_t<TContainer const>;
 };
+
+template <overload_c TSequence>
+decltype(auto) source(Gaps<TSequence, ArrayGaps> const & gaps)
+{
+    return value(gaps._source);
+}
+
+template <overload_c TSequence>
+decltype(auto) source(Gaps<TSequence, ArrayGaps> & gaps)
+{
+    return value(gaps._source);
+}
+
+template <overload_c TSequence>
+inline void assignSource(Gaps<TSequence, ArrayGaps> & gaps, TSequence const & source)
+{
+    setValue(gaps._source, source);
+    _reinitArrayGaps(gaps);
+}
 
 // –---------------------------------------------------------------------------
 // range stuff


### PR DESCRIPTION
fixes #189 

---

SeqAn2 deep internally expects things to be default-constructible which some of our view are no longer. It is also no longer possible to workaround this... but it is possible to specialise lots of stuff within in SeqAn2 to not trigger any default-initialisations which is super-unsafe... but works ™️ 

---

SeqAn2 is both 💩 and 🎉 because while the craziness is infinite, you can always work around it, by adding more 💩 