### PR TITLE
[patch, test] md5 generates a different output to md5sum

### DIFF
--- a/test/cli/index_test.cpp
+++ b/test/cli/index_test.cpp
@@ -11,8 +11,8 @@ struct index_test : public cli_test
     {
         if (std::system("echo foo | md5sum > /dev/null 2>&1") == 0)
             md5_cmd = "md5sum";
-        else if (std::system("echo foo | md5 > /dev/null 2>&1") == 0)
-            md5_cmd = "md5";
+        else if (std::system("echo foo | md5 -r > /dev/null 2>&1") == 0)
+            md5_cmd = "md5 -r";
 
         ASSERT_FALSE(md5_cmd.empty());
     }

--- a/test/cli/search_test.cpp
+++ b/test/cli/search_test.cpp
@@ -11,8 +11,8 @@ struct search_test : public cli_test
     {
         if (std::system("echo foo | md5sum > /dev/null 2>&1") == 0)
             md5_cmd = "md5sum";
-        else if (std::system("echo foo | md5 > /dev/null 2>&1") == 0)
-            md5_cmd = "md5";
+        else if (std::system("echo foo | md5 -r > /dev/null 2>&1") == 0)
+            md5_cmd = "md5 -r";
 
         ASSERT_FALSE(md5_cmd.empty());
     }


### PR DESCRIPTION
Output of `md5sum somefile.txt`:
```
a4d518904c07e3e75fa612890e5c813  somefile.txt
```

Output of `md5 somefile.txt`:
```
MD5 (somefile.txt) = a4d518904c07e3e75fa612890e5c813
```

The way the test works, is they take the first value from the file, which is not the hash value in case of `md5`.

Fix is to run `md5 -r somefile.txt` which outputs:
```
a4d518904c07e3e75fa612890e5c813 somefile.txt
```