### PR TITLE
Re-activate pre-scoring = 1 if no reduction is used

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "seqan"]
 	path = include/seqan
-	url = git://github.com/seqan/seqan.git
+	url = ../../seqan/seqan.git

--- a/src/search_options.hpp
+++ b/src/search_options.hpp
@@ -835,10 +835,9 @@ parseCommandLine(LambdaOptions & options, int argc, char const ** argv)
     // TODO always prescore 1
     getOptionValue(options.preScoring, parser, "pre-scoring");
 
-    //TODO reactivate
-//     if ((!isSet(parser, "pre-scoring")) &&
-//         (options.alphReduction == 0))
-//         options.preScoring = 1;
+    if ((!isSet(parser, "pre-scoring")) &&
+        (options.reducedAlphabet == options.transAlphabet))
+        options.preScoring = 1;
 
     getOptionValue(options.preScoringThresh, parser, "pre-scoring-threshold");
 //     if (options.preScoring == 0)

--- a/src/shared_misc.hpp
+++ b/src/shared_misc.hpp
@@ -26,7 +26,10 @@
 #include <locale>
 #include <type_traits>
 #include <forward_list>
-#include <sys/sysctl.h>
+
+#if __has_include(<sys/sysctl.h>)
+    #include <sys/sysctl.h>
+#endif
 
 #include <seqan/basic.h>
 #include <seqan/sequence.h>


### PR DESCRIPTION
This PR re-activates the pre-scoring default for unreduced sequences as stated in the help message (mainly important for nucleotide mode). Additionally, some minor fixes that have been already adjusted in lambda3 but were missing in lambda2.