### PR TITLE
Fasta formats

### DIFF
--- a/src/mkindex_options.hpp
+++ b/src/mkindex_options.hpp
@@ -92,7 +92,7 @@ void parseCommandLine(LambdaIndexerOptions & options, int argc, char const ** ar
 
     parser.add_section("Input Options");
 
-    std::vector<std::string> extensions{"fa", "fq", "fasta", "fastq"};
+    std::vector<std::string> extensions{"fa", "fq", "fasta", "fastq", "fna", "faa"};
 #ifdef SEQAN_HAS_ZLIB
     for (auto const & ext : extensions)
         extensions.push_back(ext + ".gz");

--- a/src/search_options.hpp
+++ b/src/search_options.hpp
@@ -154,7 +154,7 @@ void parseCommandLine(LambdaOptions & options, int argc, char const ** argv)
 
     parser.add_section("Input options");
 
-    std::vector<std::string> extensions{"fa", "fq", "fasta", "fastq"};
+    std::vector<std::string> extensions{"fa", "fq", "fasta", "fastq", "fna", "faa"};
 #ifdef SEQAN_HAS_ZLIB
     for (auto const & ext : extensions)
         extensions.push_back(ext + ".gz");

--- a/test/data/datasources.cmake
+++ b/test/data/datasources.cmake
@@ -191,9 +191,6 @@ declare_datasource (FILE output_blastx_fm_fast.m8
 declare_datasource (FILE output_blastx_fm_fast.sam
                     URL ${BASEURL}/output_files/output_blastx_fm_fast.sam
                     URL_HASH SHA256=557394a3c75c2da49d3d15c34f10f1eca2e4a934102cfbe92081df0f704b1828)
-declare_datasource (FILE output_blastx_fm_lazy.m8
-                    URL ${BASEURL}/output_files/output_blastx_fm_lazy.m8
-                    URL_HASH SHA256=d3bb3a5f101e9deab0b7605b83d3c2ce03270545923a65d10b0c7afb52c324b7)
 declare_datasource (FILE output_blastx_fm_pairs_default.m8
                     URL ${BASEURL}/output_files/output_blastx_fm_pairs_default.m8
                     URL_HASH SHA256=9479d7bb3ca8e53b1d425b70867f0d4aeecd73026596997724f4b1d3458ea16f)


### PR DESCRIPTION
Allow ```.fna``` and ```.faa``` file extensions for database and query files.